### PR TITLE
Quick fix to support multidimensional prediction

### DIFF
--- a/src/RandomForestSurrogate.jl
+++ b/src/RandomForestSurrogate.jl
@@ -31,7 +31,7 @@ function RandomForestSurrogate(x,y,lb,ub,num_round)
 end
 
 function (rndfor::RandomForestSurrogate)(val)
-    return XGBoost.predict(rndfor.bst,reshape(collect(val),1,2))[1]
+    return XGBoost.predict(rndfor.bst,reshape(collect(val),1,length(val)))[1]
 end
 
 function add_point!(rndfor::RandomForestSurrogate,x_new,y_new)

--- a/test/random_forest.jl
+++ b/test/random_forest.jl
@@ -13,12 +13,12 @@ add_point!(my_forest_1D,6.0,19.0)
 add_point!(my_forest_1D,[7.0,8.0],obj_1D.([7.0,8.0]))
 
 #ND
-lb = [0.0,0.0]
-ub = [10.0,10.0]
+lb = [0.0,0.0,0.0]
+ub = [10.0,10.0,10.0]
 x = sample(5,lb,ub,SobolSample())
-obj_ND = x -> x[1] * x[2]^2
+obj_ND = x -> x[1] * x[2]^2 * x[3]
 y = obj_ND.(x)
 my_forest_ND = RandomForestSurrogate(x,y,lb,ub,num_round)
-val = my_forest_ND((1.0,1.0))
-add_point!(my_forest_ND,(1.0,1.0),1.0)
-add_point!(my_forest_ND,[(1.2,1.2),(1.5,1.5)],[1.728,3.375])
+val = my_forest_ND((1.0,1.0,1.0))
+add_point!(my_forest_ND,(1.0,1.0,1.0),1.0)
+add_point!(my_forest_ND,[(1.2,1.2,1.0),(1.5,1.5,1.0)],[1.728,3.375])


### PR DESCRIPTION
There was a small bug for point predictions with the `RandomForestSurrogate`. MWE below:

```
using Surrogates

lb = [0.0,0.0,0.0]
ub = [10.0,10.0,10.0]
x = sample(5,lb,ub,SobolSample())
obj_ND = x -> x[1] * x[2]^2 * x[3]
y = obj_ND.(x)
my_forest_ND = RandomForestSurrogate(x,y,lb,ub,num_round)
val = my_forest_ND((1.0,1.0,1.0))
```

This PR fixes the issue.