### PR TITLE
Stheno backend for Kriging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+Stheno = "8188c328-b5d6-583d-959b-9690869a5511"
 
 [targets]
-test = ["Cubature", "ForwardDiff", "Flux", "QuadGK", "Test", "Tracker", "XGBoost", "Zygote"]
+test = ["Cubature", "ForwardDiff", "Flux", "QuadGK", "Test", "Tracker", "XGBoost", "Zygote", "Stheno"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,10 @@ makedocs(
         "Surrogates" => "surrogate.md",
         "Optimization" => "optimizations.md"
         ]
-    "Tutorials" => "tutorials.md"
+    "Tutorials" => [
+        "Basics" => "tutorials.md",
+        "Custom Kriging with Stheno" => "stheno.md"
+        ]
     "Contributing" => "contributing.md"
     ]
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,11 +23,14 @@ The available surrogates are:
 - Linear
 - Radial Basis
 - Kriging
+- Custom Kriging provided with Stheno
 - Neural Network
-- Support vector machine
+- Support Vector Machine
 - Random Forest
+- Second Order Polynomial
+- Inverse Distance
 
-After the Surrogate is built, we need to optimize it with respect to some objective function.
+After the surrogate is built, we need to optimize it with respect to some objective function.
 That is, simultaneously looking for a minimum **and** sampling the most unknown region.  
 The available optimization methods are:
 
@@ -36,11 +39,50 @@ The available optimization methods are:
 - Expected improvement (EI)
 - Dynamic coordinate search (DYCORS)
 
+## Multi-output Surrogates
+
+In certain situations, the function being modeled may have a multi-dimensional output space.
+In such a case, the surrogate models can take advantage of correlations between the
+observed output variables to obtain more accurate predictions.
+
+When constructing the original surrogate, each element of the passed `y` vector should
+itself be a vector. For example, the following `y` are all valid.
+
+```
+using Surrogates
+using StaticArrays
+
+x = sample(5, [0.0; 0.0], [1.0; 1.0], SobolSample())
+f_static = (x) -> StaticVector(x[1], log(x[2]*x[1]))
+f = (x) -> [x, log(x)/2]
+
+y = f_static.(x)
+y = f.(x)
+```
+
+Currently, the following are implemented as multi-output surrogates:
+
+- Radial Basis
+- Neural Network (via Flux)
+- Second Order Polynomial
+- Inverse Distance
+- Custom Kriging (via Stheno)
+
+## Gradients
+
+The surrogates implemented here are all automatically differentiable via Zygote. Because
+of this property, surrogates are useful models for processes which aren't explicitly
+differentiable, and can be used as layers in, for instance, Flux models.
 
 # Installation
-In the REPL:
+Surrogates is registered in the Julia General Registry. In the REPL:
 ```
-]add https://github.com/JuliaDiffEq/Surrogates.jl
+]add Surrogates
+```
+
+You can obtain the current master with:
+```
+]add https://github.com/JuliaDiffEq/Surrogates.jl#master
 ```
 
 # Quick example

--- a/docs/src/optimizations.md
+++ b/docs/src/optimizations.md
@@ -7,17 +7,17 @@ surrogate_optimize(obj::Function,::SRBF,lb,ub,surr::AbstractSurrogate,sample_typ
 
 * LCBS
 ```@docs
-surrogate_optimize(obj::Function,::LCBS,lb,ub,krig::Kriging,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
+surrogate_optimize(obj::Function,::LCBS,lb,ub,krig,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
 ```
 
 * EI
 ```@docs
-surrogate_optimize(obj::Function,::EI,lb,ub,krig::Kriging,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
+surrogate_optimize(obj::Function,::EI,lb,ub,krig,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
 ```
 
 * DYCORS
 ```@docs
-surrogate_optimize(obj::Function,::DYCORS,lb,ub,krig::Kriging,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
+surrogate_optimize(obj::Function,::DYCORS,lb,ub,krig,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
 ```
 
 ## Adding another optimization method

--- a/docs/src/stheno.md
+++ b/docs/src/stheno.md
@@ -1,0 +1,100 @@
+## Simple Usage
+
+A Kriging surrogate based on Stheno can work right out of the box, although your mileage
+may vary.
+
+```
+using Stheno
+using Surrogates
+
+num_samples = 10
+lb = 0.0
+ub = 10.0
+
+#Sampling
+x = sample(num_samples,lb,ub,SobolSample())
+f = x-> log(x)*x^2+x^3
+y = f.(x)
+
+surrogate = SthenoKriging(x, y)
+
+# predicting at a point
+surrogate(1.0)
+
+# the standard error at a point
+std_error_at_point(surrogate, 1.0)
+```
+
+## Tuning Gaussian Process/Kriging Hyperparameters
+
+We may be interested in a surrogate for a multi-dimensional input.
+
+```
+using Stheno
+using Surrogates
+
+num_samples = 10
+lb = [0.0; -10.0]
+ub = [1.0;  10.0]
+
+#Sampling
+x = sample(num_samples, lb, ub, SobolSample())
+f = x-> log(1+x[1]+x[2]^2)
+y = f.(x)
+```
+
+Additionally, the default hyperparameters of the Gaussian processes may be inappropriate
+for our problem. There are an number of ways to do this, as shown in the [Stheno tutorial](https://willtebbutt.github.io/Stheno.jl/dev/getting_started/).
+
+Suppose we have defined our Gaussian process (note that each dimension has a different
+scaling):
+
+```
+l = [1.0; 5.0]
+σ² = 0.05
+gp = Stheno.GP(σ² * stretch(matern52(), 1 ./ l), Stheno.GPC())
+```
+
+We can then pass this to our surrogate fitting process.
+
+```
+surrogate = SthenoKriging(x, y, gp)
+```
+
+## A Multidimensional Example
+
+Lastly, if we would like to fit a multi-output surrogate with Kriging, we could do
+the following. Note that we co-define the two Gaussian processes within the Stheno model.
+
+```
+using Stheno
+using Surrogates
+
+num_samples = 10
+lb = [0.0; -10.0]
+ub = [1.0;  10.0]
+
+#Sampling
+x = sample(num_samples, lb, ub, SobolSample())
+f = x-> [log(1+x[1]+x[2]^2), x[1]]
+y = f.(x)
+
+l = [1.0; 5.0]
+σ² = 0.05
+Stheno.@model function m()
+    gp1 = GP(σ² * stretch(matern52(), 1 ./ l))
+    gp2 = GP(σ² * stretch(matern52(), 1 ./ l)) + gp1
+    return gp1, gp2
+end
+
+gps = m()
+
+surrogate = SthenoKriging(x, y, gps)
+```
+
+Now, we see that the covariance between the two processes is non-zero:
+```
+x = ColVecs([3.0; 1.0][:, :])
+x′ = ColVecs([1.5; 1.5][:, :])
+Stheno.cov(surrogate.gp_posterior[1], surrogate.gp_posterior[2], x, x′)
+```

--- a/docs/src/surrogate.md
+++ b/docs/src/surrogate.md
@@ -22,6 +22,11 @@ RadialBasis(x,y,bounds,phi::Function,q::Int)
 Kriging(x,y,p,theta)
 ```
 
+* Kriging surrogate based on a Stheno backend
+```@docs
+SthenoKriging
+```
+
 * Lobachesky surrogate
 ```@docs
 LobacheskySurrogate(x,y,alpha,n::Int,lb,ub)

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -358,7 +358,7 @@ Under a Gaussian process (GP) prior, the goal is to minimize:
 ``LCB(x) := E[x] - k * \\sqrt{(V[x])}``
 default value ``k = 2``.
 """
-function surrogate_optimize(obj::Function,::LCBS,lb::Number,ub::Number,krig::Kriging,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
+function surrogate_optimize(obj::Function,::LCBS,lb::Number,ub::Number,krig,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
     #Default value
     k = 2.0
     dtol = 1e-3 * norm(ub-lb)
@@ -416,7 +416,7 @@ Under a Gaussian process (GP) prior, the goal is to minimize:
 
 default value ``k = 2``.
 """
-function surrogate_optimize(obj::Function,::LCBS,lb,ub,krig::Kriging,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
+function surrogate_optimize(obj::Function,::LCBS,lb,ub,krig,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
     #Default value
     k = 2.0
     dtol = 1e-3 * norm(ub-lb)
@@ -472,7 +472,7 @@ end
 """
 Expected improvement method 1D
 """
-function surrogate_optimize(obj::Function,::EI,lb::Number,ub::Number,krig::Kriging,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
+function surrogate_optimize(obj::Function,::EI,lb::Number,ub::Number,krig,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
         dtol = 1e-3*norm(ub-lb)
         eps = 0.01
         for i = 1:maxiters
@@ -533,7 +533,7 @@ maximize expected improvement:
 
 
 """
-function surrogate_optimize(obj::Function,::EI,lb,ub,krig::Kriging,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
+function surrogate_optimize(obj::Function,::EI,lb,ub,krig,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
         dtol = 1e-3*norm(ub-lb)
         eps = 0.01
         for i = 1:maxiters

--- a/src/SthenoKriging.jl
+++ b/src/SthenoKriging.jl
@@ -1,0 +1,94 @@
+export SthenoKriging
+
+mutable struct SthenoKriging{X, Y, GP, TΣy, GP_P} <: AbstractSurrogate
+    x::X
+    y::Y
+    gp::GP
+    Σy::TΣy
+    gp_posterior::GP_P
+ end
+
+ """
+     SthenoKriging(x::X, y::Y, GP::Stheno.GP=Stheno.GP(Stheno.EQ(), Stheno.GPC()), σ²=1e-18)
+
+Returns a Kriging (or Gaussian process) surrogate conditioned on the data points `x` and `y`.
+The `GP` is the base Gaussian process defined with Stheno.
+
+# Arguments
+- `x::X`: Vector containing the observation points
+- `y::Y`: Vector containing the observed points
+- `GP::Stheno.GP`: The base Gaussian process used to condition over. A simple prior is
+provided as default. If there are multiple observation dimensions, a `Tuple` of Gaussian
+processes can be passed, otherwise the same process is used across all dimensions.
+- `σ²`=1e-18: Variance of the observation noise, default is equivalent to no noise
+"""
+function SthenoKriging(x, y, gp=Stheno.GP(Stheno.EQ(), Stheno.GPC()), σ²=1e-18)
+    gp_posteriors = _prepare_gps(x, y, gp, σ²)
+
+    return SthenoKriging(x, y, gp, σ², gp_posteriors)
+end
+
+
+"""
+    function (k::SthenoKriging)(val)
+
+Gives the mean predicted value for the `SthenoKriging` object.
+"""
+function (k::SthenoKriging)(x)
+    X = Stheno.ColVecs([x[i] for i = 1:length(x), j = 1:1])
+    nobs = length(k.y[1])
+
+    ŷ = [first(Stheno.mean_vector(k.gp_posterior[i], X)) for i=1:nobs]
+
+    return _match_container(ŷ, first(k.y))
+end
+
+function std_error_at_point(k::SthenoKriging, x)
+    X = Stheno.ColVecs([x[i] for i = 1:length(x), j = 1:1])
+    nobs = length(k.y[1])
+
+    std_err = [sqrt(first(Stheno.cov(k.gp_posterior[i], X))) for i=1:nobs]
+
+    return _match_container(std_err, first(k.y))
+end
+
+
+"""
+    add_point!(k::SthenoKriging, x_new, y_new)
+
+Adds the new point(s) and its respective value(s) to the sample points, re-conditioning
+the surrogate on the updated values.
+"""
+function add_point!(k::SthenoKriging, x_new, y_new)
+    if eltype(x_new) == eltype(k.x)
+        append!(k.x, x_new)
+        append!(k.y, y_new)
+    else
+        push!(k.x, x_new)
+        push!(k.y, y_new)
+    end
+
+    k.gp_posterior = _prepare_gps(k.x, k.y, k.gp, k.Σy)
+    return nothing
+end
+
+function _prepare_gps(x, y, gps, σ²)
+    X = Stheno.ColVecs([x[j][i] for i = 1:length(x[1]), j = 1:length(x)])
+    Y = [[y[i][j] for i in 1:length(y)] for j in 1:length(first(y))]
+    gp_posteriors = _condition_gps(X, Y, gps, σ²)
+
+    return gp_posteriors
+end
+function _condition_gps(X, Y, gp::Stheno.AbstractGP, σ²)
+    nobs = length(Y)
+    gp_posts = ntuple(i -> gp, nobs) | ntuple(i -> Obs(gp(X, σ²), Y[i]), nobs)
+
+    return gp_posts
+end
+function _condition_gps(X, Y, gps, σ²)
+    nobs = length(Y)
+    @assert length(gps) == nobs
+    gp_posts = gps | ntuple(i -> Obs(gps[i](X, σ²), Y[i]), nobs)
+
+    return gp_posts
+end

--- a/src/SthenoKriging.jl
+++ b/src/SthenoKriging.jl
@@ -41,7 +41,7 @@ end
 Gives the mean predicted value for the `SthenoKriging` object.
 """
 function (k::SthenoKriging)(x)
-    X = Stheno.ColVecs([x[i] for i = 1:length(x), j = 1:1])
+    X = _query_to_colvec(x)
     nobs = length(k.y[1])
 
     ŷ = [first(Stheno.mean_vector(k.gp_posterior[i], X)) for i=1:nobs]
@@ -50,13 +50,16 @@ function (k::SthenoKriging)(x)
 end
 
 function std_error_at_point(k::SthenoKriging, x)
-    X = Stheno.ColVecs([x[i] for i = 1:length(x), j = 1:1])
+    X = _query_to_colvec(x)
     nobs = length(k.y[1])
 
     std_err = [sqrt(abs(first(Stheno.cov(k.gp_posterior[i], X)))) for i=1:nobs]
 
     return _match_container(std_err, first(k.y))
 end
+_query_to_colvec(x::Number) = Stheno.ColVecs(reshape([x], length(x), 1))
+_query_to_colvec(x::Tuple) = Stheno.ColVecs(reshape([x...], length(x), 1))
+_query_to_colvec(x) = Stheno.ColVecs(reshape(x, length(x), 1))
 
 
 """

--- a/src/Surrogates.jl
+++ b/src/Surrogates.jl
@@ -39,6 +39,11 @@ function __init__()
         using LIBSVM
         include("SVMSurrogate.jl")
     end
+
+    @require Stheno = "8188c328-b5d6-583d-959b-9690869a5511" begin
+        using Stheno
+        include("SthenoKriging.jl")
+    end
 end
 
 

--- a/test/AD_compatibility.jl
+++ b/test/AD_compatibility.jl
@@ -197,33 +197,28 @@ my_rad = RadialBasis(x,y,lb,ub,x->norm(x),2)
 g = x -> my_rad'(x)
 g(5.0)
 
-Zygote.refresh()
 #Kriging
 p = 1.5
 my_krig = Kriging(x,y,p)
 g = x -> my_krig'(x)
 g(5.0)
 
-Zygote.refresh()
 #Linear Surrogate
 my_linear = LinearSurrogate(x,y,lb,ub)
 g = x -> my_linear'(x)
 g(5.0)
 
-Zygote.refresh()
 #Inverse distance
 p = 1.4
 my_inverse = InverseDistanceSurrogate(x,y,p,lb,ub)
 g = x -> my_inverse'(x)
 g(5.0)
 
-Zygote.refresh()
 #Second order polynomial
 my_second = SecondOrderPolynomialSurrogate(x,y,lb,ub)
 g = x -> my_second'(x)
 g(5.0)
 
-Zygote.refresh()
 #Lobachesky
 n = 4
 α = 2.4
@@ -232,7 +227,6 @@ g = x -> my_loba'(x)
 g(0.0)
 
 #NN
-Zygote.refresh()
 model = Chain(Dense(1,1), first)
 loss(x, y) = Flux.mse(model(x), y)
 opt = Descent(0.01)
@@ -256,7 +250,6 @@ g = x -> Zygote.gradient(my_rad,x)
 g((2.0,5.0))
 
 #Kriging
-Zygote.refresh()
 theta = [2.0,2.0]
 p = [1.9,1.9]
 my_krig = Kriging(x,y,p,theta)
@@ -264,13 +257,11 @@ g = x -> Zygote.gradient(my_krig,x)
 g((2.0,5.0))
 
 #Linear Surrogate
-Zygote.refresh()
 my_linear = LinearSurrogate(x,y,lb,ub)
 g = x -> Zygote.gradient(my_linear,x)
 g((2.0,5.0))
 
 #Inverse Distance
-Zygote.refresh()
 p = 1.4
 my_inverse = InverseDistanceSurrogate(x,y,p,lb,ub)
 g = x -> Zygote.gradient(my_inverse,x)
@@ -287,13 +278,11 @@ g((2.0,5.0))
 =#
 
 #Second order polynomial mutating arrays
-Zygote.refresh()
 my_second = SecondOrderPolynomialSurrogate(x,y,lb,ub)
 g = x -> Zygote.gradient(my_second,x)
 g((2.0,5.0))
 
 #NN
-Zygote.refresh()
 model = Chain(Dense(2,1), first)
 loss(x, y) = Flux.mse(model(x), y)
 opt = Descent(0.01)
@@ -312,7 +301,6 @@ f = x -> [x[1]^2, x[2]]
 y = f.(x)
 
 #NN
-Zygote.refresh()
 model = Chain(Dense(2,2))
 loss(x, y) = Flux.mse(model(x), y)
 opt = Descent(0.01)
@@ -320,16 +308,13 @@ n_echos = 1
 my_neural = NeuralSurrogate(x,y,lb,ub,model,loss,opt,n_echos)
 Zygote.gradient(x -> sum(my_neural(x)), (2.0, 5.0))
 
-Zygote.refresh()
 my_rad = RadialBasis(x,y,[lb,ub],z->norm(z),1)
 Zygote.gradient(x -> sum(my_rad(x)), (2.0, 5.0))
 
-Zygote.refresh()
 p = 1.4
 my_inverse = InverseDistanceSurrogate(x,y,p,lb,ub)
 my_inverse((2.0, 5.0))
 Zygote.gradient(x -> sum(my_inverse(x)), (2.0, 5.0))
 
-Zygote.refresh()
 my_second = SecondOrderPolynomialSurrogate(x,y,lb,ub)
 Zygote.gradient(x -> sum(my_second(x)), (2.0, 5.0))

--- a/test/SthenoKriging.jl
+++ b/test/SthenoKriging.jl
@@ -5,12 +5,137 @@ using Test
 
 @testset "1D - 1D" begin
 
-lb = 0.0
-ub = 10.0
-f = x -> log(x)*exp(x)
-x = sample(5,lb,ub,SobolSample())
-y = f.(x)
-my_k = SthenoKriging(x,y)
-add_point!(my_k,4.0,75.68)
-add_point!(my_k,[5.0,6.0],[238.86,722.84])
-pred = my_k(5.5)
+    lb = 0.0
+    ub = 10.0
+    f = x -> log(x)*exp(x)
+    x = sample(5,lb,ub,SobolSample())
+    y = f.(x)
+    my_k = SthenoKriging(x,y)
+    x_new = 4.0
+    y_new = f.(x_new)
+    add_point!(my_k, x_new, y_new)
+    xs_new = [5.0, 6.0]
+    ys_new = f.(xs_new)
+    add_point!(my_k, xs_new, ys_new)
+    y_pred = f(x_new)
+    pred = my_k(x_new)
+    @test pred ≈ y_pred
+    pred_std = std_error_at_point(my_k, x_new)
+    @test pred_std ≈ zero(y_pred) atol=1e-6
+
+    @testset "AD" begin
+    end
+
+    @testset "Optimization" begin
+    end
+end
+
+@testset "ND - 1D" begin
+
+    lb = [0.0; 0.0]
+    ub = [5.0; 10.0]
+    f = x -> log(x[1])*exp(x[2])
+    x = sample(5,lb,ub,SobolSample())
+    y = f.(x)
+    my_k = SthenoKriging(x,y)
+    x_new = (2.0, 1.0)
+    y_new = f(x_new)
+    add_point!(my_k, x_new, y_new)
+    xs_new = [(1.0, 2.0), (0.5, 2.5)]
+    ys_new = f.(xs_new)
+    add_point!(my_k, xs_new, ys_new)
+    y_pred = f(x_new)
+    pred = my_k(x_new)
+    @test pred ≈ y_pred
+    pred_std = std_error_at_point(my_k, x_new)
+    @test pred_std ≈ zero(y_pred) atol=1e-6
+
+    @testset "AD" begin
+    end
+    @testset "Optimization" begin
+    end
+end
+
+@testset "1D - ND" begin
+
+    lb = 0.0
+    ub = 10.0
+    f = x -> [x, x^2]
+    x = sample(5,lb,ub,SobolSample())
+    y = f.(x)
+
+    my_k = SthenoKriging(x,y,Stheno.GP(Stheno.EQ(), Stheno.GPC()))
+    x_new = 4.0
+    y_new = f.(x_new)
+    add_point!(my_k, x_new, y_new)
+    xs_new = [5.0, 6.0]
+    ys_new = f.(xs_new)
+    add_point!(my_k, xs_new, ys_new)
+    y_pred = f(x_new)
+    pred = my_k(x_new)
+    @test pred ≈ y_pred
+    pred_std = std_error_at_point(my_k, x_new)
+    @test pred_std ≈ zero(y_pred) atol=1e-6
+
+    # separate Stheno models
+    gpc = Stheno.GPC()
+    gp1 = Stheno.GP(Stheno.EQ(), gpc)
+    gp2 = Stheno.GP(Stheno.Exp(), gpc)
+    my_k = SthenoKriging(x, y, (gp1, gp2))
+    x_new = 0.2
+    y_new = f.(x_new)
+    add_point!(my_k, x_new, y_new)
+    xs_new = [5.5, 6.5]
+    ys_new = f.(xs_new)
+    add_point!(my_k, xs_new, ys_new)
+    y_pred = f(x_new)
+    pred = my_k(x_new)
+    @test pred ≈ y_pred
+    pred_std = std_error_at_point(my_k, x_new)
+    @test pred_std ≈ zero(y_pred) atol=1e-6
+
+    @testset "AD" begin
+    end
+end
+
+@testset "ND - ND" begin
+
+    lb = [0.0; 0.0]
+    ub = [5.0; 10.0]
+    f = x -> [x[1]*x[2], x[2]^2]
+    x = sample(5,lb,ub,SobolSample())
+    y = f.(x)
+
+    my_k = SthenoKriging(x,y,Stheno.GP(Stheno.EQ(), Stheno.GPC()))
+    x_new = (1.0, 1.0)
+    y_new = f(x_new)
+    add_point!(my_k, x_new, y_new)
+    xs_new = [(1.0, 2.0), (0.5, 2.5)]
+    ys_new = f.(xs_new)
+    add_point!(my_k, xs_new, ys_new)
+    y_pred = f(x_new)
+    pred = my_k(x_new)
+    @test pred ≈ y_pred
+    pred_std = std_error_at_point(my_k, x_new)
+    @test pred_std ≈ zero(y_pred) atol=1e-6
+
+    # separate Stheno models
+    gpc = Stheno.GPC()
+    gp1 = Stheno.GP(Stheno.EQ(), gpc)
+    gp2 = Stheno.GP(Stheno.Exp(), gpc)
+    my_k = SthenoKriging(x, y, (gp1, gp2))
+    x_new = (0.2, 0.1)
+    y_new = f(x_new)
+    add_point!(my_k, x_new, y_new)
+    xs_new = [(5.5, 0.5), (6.5, 0.5)]
+    ys_new = f.(xs_new)
+    add_point!(my_k, xs_new, ys_new)
+    y_pred = f(x_new)
+    pred = my_k(x_new)
+    @test pred ≈ y_pred
+    pred_std = std_error_at_point(my_k, x_new)
+    @test pred_std ≈ zero(y_pred) atol=1e-6
+
+    @testset "AD" begin
+    end
+end

--- a/test/SthenoKriging.jl
+++ b/test/SthenoKriging.jl
@@ -24,6 +24,7 @@ using Test
     @test pred_std ≈ zero(y_pred) atol=1e-6
 
     @testset "AD" begin
+        Zygote.gradient(x -> my_k(x), 1.0)
     end
 
     @testset "Optimization" begin
@@ -51,6 +52,9 @@ end
     @test pred_std ≈ zero(y_pred) atol=1e-6
 
     @testset "AD" begin
+        g1 = Zygote.gradient(x -> my_k(x), (1.0, 1.0))[1]
+        g2 = Zygote.gradient(x -> my_k(x), [1.0, 1.0])[1]
+        @test [g1...] ≈ g2
     end
     @testset "Optimization" begin
     end
@@ -95,6 +99,7 @@ end
     @test pred_std ≈ zero(y_pred) atol=1e-6
 
     @testset "AD" begin
+        Zygote.gradient(x -> sum(my_k(x)), 1.0)
     end
 end
 
@@ -137,5 +142,8 @@ end
     @test pred_std ≈ zero(y_pred) atol=1e-6
 
     @testset "AD" begin
+        g1 = Zygote.gradient(x -> sum(my_k(x)), (1.1, 1.1))[1]
+        g2 = Zygote.gradient(x -> sum(my_k(x)), [1.1, 1.1])[1]
+        @test [g1...] ≈ g2
     end
 end

--- a/test/SthenoKriging.jl
+++ b/test/SthenoKriging.jl
@@ -28,6 +28,14 @@ using Test
     end
 
     @testset "Optimization" begin
+        objective_function = x -> 2*x+1
+        x = [2.0,4.0,6.0]
+        y = [5.0,9.0,13.0]
+        p = 2
+        a = 2
+        b = 6
+        my_k_EI1 = SthenoKriging(x,y)
+        surrogate_optimize(objective_function,EI(),a,b,my_k_EI1,UniformSample(),maxiters=200,num_new_samples=155)
     end
 end
 
@@ -57,6 +65,15 @@ end
         @test [g1...] ≈ g2
     end
     @testset "Optimization" begin
+        objective_function_ND = z -> 3*hypot(z...)+1
+        x = [(1.2,3.0),(3.0,3.5),(5.2,5.7)]
+        y = objective_function_ND.(x)
+        theta = [2.0,2.0]
+        lb = [1.0,1.0]
+        ub = [6.0,6.0]
+
+        my_k_E1N = SthenoKriging(x,y)
+        surrogate_optimize(objective_function_ND,EI(),lb,ub,my_k_E1N,UniformSample())
     end
 end
 

--- a/test/SthenoKriging.jl
+++ b/test/SthenoKriging.jl
@@ -1,0 +1,16 @@
+using Surrogates
+using Stheno
+using Zygote
+using Test
+
+@testset "1D - 1D" begin
+
+lb = 0.0
+ub = 10.0
+f = x -> log(x)*exp(x)
+x = sample(5,lb,ub,SobolSample())
+y = f.(x)
+my_k = SthenoKriging(x,y)
+add_point!(my_k,4.0,75.68)
+add_point!(my_k,[5.0,6.0],[238.86,722.84])
+pred = my_k(5.5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,4 @@ using Surrogates
 @testset "InverseDistanceSurrogate" begin include("inverseDistanceSurrogate.jl") end
 @testset "SecondOrderPolynomialSurrogate" begin include("secondOrderPolynomialSurrogate.jl") end
 @testset "AD_Compatibility" begin include("AD_compatibility.jl") end
-@testset "SthenoKriging.jl" begin include("Kriging.jl") end
+@testset "SthenoKriging.jl" begin include("SthenoKriging.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,4 @@ using Surrogates
 @testset "InverseDistanceSurrogate" begin include("inverseDistanceSurrogate.jl") end
 @testset "SecondOrderPolynomialSurrogate" begin include("secondOrderPolynomialSurrogate.jl") end
 @testset "AD_Compatibility" begin include("AD_compatibility.jl") end
+@testset "SthenoKriging.jl" begin include("Kriging.jl") end


### PR DESCRIPTION
Ref #98, #100 

I've added a new surrogate type, `SthenoKriging`, which provides a relatively lightweight glue to `Stheno`. AD and surrogate optimization (in the case of ND -> 1D) work for this new surrogate type.

I've also updated the documentation to give examples of how to use `Stheno` for the surrogate modeling use case. One links to the Stheno documentation for Gaussian processes to demonstrate how to optimize hyperparameters, and another demonstrates how to build a Stheno model (and collection of Gaussian processes) where the conditioned processes exhibit nonzero covariance between themselves.